### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/browser-hist.el
+++ b/browser-hist.el
@@ -21,6 +21,8 @@
 ;;
 ;;; Code:
 
+(require 'subr-x)
+
 (defgroup browser-hist nil
   "browser-hist group"
   :prefix "browser-hist-"


### PR DESCRIPTION
This fixes the following warnings.

```
In browser-hist--query:
browser-hist.el:71:14: Warning: ‘seq-remove’ called with 1 argument, but
    requires 2
browser-hist.el:73:14: Warning: ‘seq-map’ called with 1 argument, but requires
    2 or more

In end of data:
browser-hist.el:69:12: Warning: the function ‘thread-last’ is not known to be
    defined.
```