### PR TITLE
Simple cache to improve performance

### DIFF
--- a/browser-hist.el
+++ b/browser-hist.el
@@ -36,7 +36,7 @@
   :group 'browser-hist
   :type '(alist :key-type symbol :value string))
 
-(defcustom browser-hist-default-browser 'brave
+(defcustom browser-hist-default-browser 'chrome
   "Default browser."
   :group 'browser-hist
   :type '(chrome brave firefox))


### PR DESCRIPTION
Avoid reloading the URLs list everytime `browser-hist-search` is called.
It can take long time in systems with a long browser history.

It's only enabled after setting `(setq browser-hist-use-cache t)`.
Cache can be reloaded calling universal argument before `browser-hist-search`.

A small improvement for https://github.com/agzam/browser-hist.el/issues/

I prefer this version as I can still use my emacs completion features, like using orderless.