### PR TITLE
browser-hist: Use a dynamic completion table

### DIFF
--- a/browser-hist.el
+++ b/browser-hist.el
@@ -27,10 +27,24 @@
 (require 'subr-x)
 (require 'browse-url)
 
+(eval-when-compile
+  (if (and (fboundp 'sqlite-available-p)
+           (sqlite-available-p))
+      (progn (defalias 'browser-hist--sqlite-open 'sqlite-open)
+             (defalias 'browser-hist--sqlite-select 'sqlite-select))
+    (require 'sqlite)
+    (defalias 'browser-hist--sqlite-open 'sqlite-init)
+    (defalias 'browser-hist--sqlite-select 'sqlite-query)))
+
 (defgroup browser-hist nil
   "browser-hist group"
   :prefix "browser-hist-"
   :group 'applications)
+
+(defcustom browser-hist-minimum-query-length 3
+  "Minimum length of the search term(s) to query the history database."
+  :type 'natnum
+  :group 'browser-hist)
 
 (defcustom browser-hist-db-paths
   (cond
@@ -66,12 +80,13 @@
   :group 'browser-hist
   :type 'boolean)
 
-(defvar browser-hist--db-queries
-  '((chrome . "select distinct title, url from urls order by last_visit_time desc")
-    (chromium . "select distinct title, url from urls order by last_visit_time desc")
-    (brave . "select distinct title, url from urls order by last_visit_time desc")
-    (firefox . "select distinct title, url from moz_places order by last_visit_date desc")
-    (safari . "select distinct v.title, i.url from history_items i join history_visits v on i.id = v.history_item order by v.visit_time desc")))
+(defvar browser-hist--db-fields
+  '((chrome   "title"   "url"   "urls"          "order by last_visit_time desc")
+    (chromium "title"   "url"   "urls"          "order by last_visit_time desc")
+    (brave    "title"   "url"   "urls"          "order by last_visit_time desc")
+    (firefox  "title"   "url"   "moz_places"    "order by last_visit_date desc")
+    (safari   "v.title" "i.url" "history_items"
+     "i join history_visits v on i.id = v.history_item order by v.visit_time desc")))
 
 (defun browser-hist--make-db-copy (browser)
   "Copy browser's history db file to a temp dir.
@@ -83,55 +98,60 @@ db, we copy the file."
          (new-fname (format "%sbhist-%s.sqlite"
                             (temporary-file-directory)
                             (symbol-name browser))))
-    (copy-file hist-db new-fname :overwite)
-    new-fname))
+    (if (or (not (file-exists-p new-fname))
+            (file-newer-than-file-p hist-db new-fname))
+        (copy-file hist-db new-fname :overwite :keep-time)
+      new-fname)))
 
-(defun browser-hist--query (browser)
-  "Query db."
-  (let* ((built-in? (and (fboundp 'sqlite-available-p)
-                         (sqlite-available-p)))
-         (db-file (browser-hist--make-db-copy browser))
-         (query (alist-get browser browser-hist--db-queries))
-         (db (if built-in?
-                 (sqlite-open db-file)
-               (progn
-                 (require 'sqlite)
-                 (sqlite-init db-file))))
-         (rows
-          (thread-last
-            (if built-in?
-                (sqlite-select db query)
-             (sqlite-query db query))
-            (seq-remove
-             (lambda (x) (or (null (car x)) (string-blank-p (car x)))))
-            (seq-map
-             (lambda (x)
-               (when (and (car x) (cadr x))
-                (cons (string-trim-right
-                       (replace-regexp-in-string
-                        (if browser-hist-ignore-query-params "\\?.*" "")
-                        "" (cadr x)) "/")
-                      (car x))))))))
+(defvar browser-hist--db-connection nil)
+
+(defun browser-hist--send-query (strings)
+  "Build the sql query from the minibuffer input"
+  (pcase-let* ((`(,title ,url ,table ,rest)
+                (alist-get browser-hist-default-browser
+                           browser-hist--db-fields))
+               (full-query
+                (cl-loop for s in (split-string strings)
+                         collect (format " ( %s LIKE '%%%s%%' OR %s LIKE '%%%s%%' ) "
+                                         title s url s)
+                         into queries
+                         finally return
+                         (concat (format "SELECT DISTINCT %s, %s FROM %s WHERE"
+                                  title url table)
+                                 (mapconcat #'identity queries " AND ")
+                                 rest)))
+               (db (or browser-hist--db-connection
+                       (setq browser-hist--db-connection
+                             (browser-hist--sqlite-open
+                              (browser-hist--make-db-copy browser-hist-default-browser)))))
+               (rows
+                (thread-last
+                  (browser-hist--sqlite-select db full-query)
+                  (seq-remove
+                   (lambda (x) (or (null (car x)) (string-blank-p (car x)))))
+                  (seq-map
+                   (lambda (x)
+                     (when (and (car x) (cadr x))
+                       (cons (string-trim-right
+                              (replace-regexp-in-string
+                               (if browser-hist-ignore-query-params "\\?.*" "")
+                               "" (cadr x)) "/")
+                             (car x))))))))
     rows))
 
-(defun browser-hist--completing-fn (coll)
-  "Filter COLL when passed to completing-read."
-  (lambda (s _ flag)
+(defun browser-hist--completion-table (s _ flag)
+  (let ((rows-raw (and (>= (length (string-trim s))
+                           browser-hist-minimum-query-length)
+                       (browser-hist--send-query s))))
     (pcase flag
       ('metadata
        `(metadata
          (annotation-function
-          ,@(lambda (x)
-              (concat
-               "\n\t"
-               (propertize
-                (alist-get x coll nil nil #'string=)
-                'face 'completions-annotations))))
-         (display-sort-function ; keep rows sorted as they come from db
-          ,@(lambda (xs) xs))
+          ,@(lambda (x) (concat "\n\t" (alist-get x rows-raw nil nil #'string=))))
+         (display-sort-function ,@(lambda (xs) xs))
          (category . url)))
-      ('t
-       (all-completions s coll)))))
+      ('nil (try-completion s rows-raw))
+      ('t (mapcar #'car rows-raw)))))
 
 (defun browser-hist--url-transformer (type target)
   "Remove title from TARGET url appended by `browser-hist-search'"
@@ -142,6 +162,7 @@ db, we copy the file."
   "Remove title from TARGET url appended by `browser-hist-search'"
   (browse-url (replace-regexp-in-string "\t.*" "" url)))
 
+;;;###autoload
 (defun browser-hist-search ()
   "Search through browser history."
   (interactive)
@@ -156,18 +177,14 @@ db, we copy the file."
        'embark-transformer-alist
        '(url . browser-hist--url-transformer))))
 
-  (let* ((coll (seq-map
-                (lambda (x)
-                  (cons
-                   (concat
-                    (car x)
-                    "\t"
-                    (propertize (cdr x) 'invisible t))
-                   (cdr x)))
-                (browser-hist--query browser-hist-default-browser)))
-         (selected (thread-last
-                     (browser-hist--completing-fn coll)
-                     (completing-read "Browser history: "))))
-    (browse-url selected)))
+  (unwind-protect
+      (let ((selected
+             (completing-read "Browser history: "
+                              #'browser-hist--completion-table)))
+        (browse-url selected))
+    (and browser-hist--db-connection
+         (ignore-errors (sqlite-close browser-hist--db-connection))
+         (setq browser-hist--db-connection nil))))
 
+(provide 'browser-hist)
 ;;; browser-hist.el ends here

--- a/browser-hist.el
+++ b/browser-hist.el
@@ -27,14 +27,23 @@
 (require 'browse-url)
 (eval-when-compile (require 'cl-lib))
 
-(eval-when-compile
+(declare-function sqlite-close "sqlite")
+
+(defmacro browser-hist--sqlite-open (file)
   (if (and (fboundp 'sqlite-available-p)
            (sqlite-available-p))
-      (progn (defalias 'browser-hist--sqlite-open 'sqlite-open)
-             (defalias 'browser-hist--sqlite-select 'sqlite-select))
+      `(sqlite-open ,file)
     (require 'sqlite)
-    (defalias 'browser-hist--sqlite-open 'sqlite-init)
-    (defalias 'browser-hist--sqlite-select 'sqlite-query)))
+    (declare-function sqlite-init  "sqlite")
+    `(sqlite-init ,file)))
+
+(defmacro browser-hist--sqlite-select (db query)
+  (if (and (fboundp 'sqlite-available-p)
+           (sqlite-available-p))
+      `(sqlite-select ,db ,query)
+    (require 'sqlite)
+    (declare-function sqlite-query  "sqlite")
+    `(sqlite-query ,db ,query)))
 
 (defgroup browser-hist nil
   "browser-hist group"


### PR DESCRIPTION
browser-hist.el (browser-hist--sqlite-open,
browser-hist--sqlite-select, browser-hist-minimum-query-length, browser-hist--db-fields, browser-hist--db-connection, browser-hist--send-query, browser-hist--completion-table, browser-hist-search):

- Instead of querying the full history every time, use a dynamic completion table and query the history database as needed.

- Don't include the annotation in the url as invisible text, this hack is no longer needed.

- Only re-copy the history database to the temp directory if it's newer.

- New variable `browser-hist-minimum-query-length` for minimum query string length -- otherwise the sql query will return everything.

- Autoload `browser-hist-search` and make `browser-hist` a feature for easy package management.

- Move checks (is sql built-in, etc) to the installation stage instead of the "runtime" stage.

- Close the db connection after using completing read -- sqlite is C code, and opening too many simultaenous connections to the db can crash or mess up the Emacs session.