### PR TITLE
optimize trimming query parameters

### DIFF
--- a/browser-hist.el
+++ b/browser-hist.el
@@ -9,7 +9,7 @@
 ;; Version: 0.0.1
 ;; Keywords: convenience hypermedia matching tools
 ;; Homepage: https://github.com/agzam/browser-hist.el
-;; Package-Requires: ((emacs "27"))
+;; Package-Requires: ((emacs "28.1"))
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -168,9 +168,10 @@ If STRINGS is nil return the latest 100 entries."
                         browser-hist-default-browser))))))
     (cl-loop for (desc link) in (browser-hist--sqlite-select db full-query)
              collect (cons (string-trim-right
-                            (replace-regexp-in-string
-                             (if browser-hist-ignore-query-params "\\?.*" "")
-                             "" link))
+                            (if-let* ((browser-hist-ignore-query-params)
+                                      (pos (string-search "?" link)))
+                                (substring link 0 pos)
+                              link))
                            desc))))
 
 (defun browser-hist--completion-table (s _ flag)


### PR DESCRIPTION
This calls `string-search` only when necessary instead of unconditionally calling `replace-regexp-in-string`.

Calling `replace-regexp-in-string` accounted for about 35% of the query time in my testing, even when the feature was unused. `string-search` doesn't show up in the profile, even when `browser-hist-ignore-query-params` is enabled.

Note: this does require Emacs 28.1 (due to `string-search`).