### PR TITLE
browser-hist: Fix defcustom type for browser-hist-default-browser

### DIFF
--- a/browser-hist.el
+++ b/browser-hist.el
@@ -85,7 +85,9 @@
 (defcustom browser-hist-default-browser 'chrome
   "Default browser."
   :group 'browser-hist
-  :type '(chrome chromium brave firefox safari qutebrowser))
+  :type '(choice (const chrome) (const chromium) (const brave)
+                 (const firefox) (const safari) (const qutebrowser)
+                 (symbol :tag "Other browser")))
 
 (defcustom browser-hist-ignore-query-params nil
   "When not nil, ignore everything after ? in url."


### PR DESCRIPTION
The previous type was an invalid raw list of symbols, not a valid Custom widget type. Replace it with a proper `choice` type that lists all supported browsers as `const` options, plus a generic `symbol` option for custom or other unsupported browsers.